### PR TITLE
Integrate test and word_t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(IndexElements STATIC
     ${LIB_DIR}/IndexElements/PostingList.cpp
     ${LIB_DIR}/IndexElements/Post.cpp
     ${LIB_DIR}/IndexElements/PostEntry.cpp
+    ${LIB_DIR}/IndexElements/WordLocation.hpp
 )
 target_include_directories(IndexElements PUBLIC ${LIB_DIR}/IndexElements)
 target_link_libraries(IndexElements PUBLIC spdlog::spdlog)

--- a/lib/DocStream/DocStream.cpp
+++ b/lib/DocStream/DocStream.cpp
@@ -11,7 +11,7 @@ bool checkTagExists(std::string line, std::string tag) {
 }
 
 DocStream::DocStream(std::string dirPath) : _dirPath(dirPath) {
-    for (const auto &entry : std::filesystem::directory_iterator(dirPath)) {
+    for (const auto& entry : std::filesystem::directory_iterator(dirPath)) {
         std::string filename = entry.path().filename();
         if (filename == "logs") {
             continue;
@@ -20,7 +20,7 @@ DocStream::DocStream(std::string dirPath) : _dirPath(dirPath) {
     }
 }
 
-std::pair<std::string, std::vector<PostEntry>> DocStream::nextFile() {
+std::pair<std::string, std::vector<word_t>> DocStream::nextFile() {
     //TODO
     //Parse the next file in the priority queue. Populate the file type struct with words in the
     //title section and normal words.
@@ -29,12 +29,12 @@ std::pair<std::string, std::vector<PostEntry>> DocStream::nextFile() {
     std::ifstream document(_dirPath + "/" + documentName);
     if (!document) {
         std::cerr << "Error opening file " << documentName << endl;
-        return std::make_pair(documentName, std::vector<PostEntry>{});
+        return std::make_pair(documentName, std::vector<word_t>{});
     }
     std::string line;
     std::getline(document, line);
     if (!checkTagExists(line, "URL: ")) {
-        return std::make_pair(documentName, std::vector<PostEntry>{});
+        return std::make_pair(documentName, std::vector<word_t>{});
     }
 
     // Get first line that contains URL
@@ -45,48 +45,48 @@ std::pair<std::string, std::vector<PostEntry>> DocStream::nextFile() {
         url = match[1];
     } else {
         std::cerr << "No URL found!" << std::endl;
-        return std::make_pair(documentName, std::vector<PostEntry>{});
+        return std::make_pair(documentName, std::vector<word_t>{});
     }
 
     // Check <title> tag
     std::getline(document, line);
     if (!checkTagExists(line, "<title>")) {
-        return std::make_pair(documentName, std::vector<PostEntry>{});
+        return std::make_pair(documentName, std::vector<word_t>{});
     }
 
     uint32_t offset = 0;
-    std::vector<PostEntry> output;
+    std::vector<word_t> output;
     // Get title words
     std::getline(document, line);
     std::istringstream titleIss(line);
     std::string word;
     while (titleIss >> word) {
-        output.push_back(PostEntry(offset, wordlocation_t::title));
+        output.push_back(word_t{word, offset, wordlocation_t::title});
         ++offset;
     }
 
     // Check </title> tag
     std::getline(document, line);
     if (!checkTagExists(line, "</title>")) {
-        return std::make_pair(documentName, std::vector<PostEntry>{});
+        return std::make_pair(documentName, std::vector<word_t>{});
     }
 
     // Check <words>  tag
     std::getline(document, line);
     if (!checkTagExists(line, "<words>")) {
-        return std::make_pair(documentName, std::vector<PostEntry>{});
+        return std::make_pair(documentName, std::vector<word_t>{});
     }
 
     std::getline(document, line);
     std::istringstream bodyIss(line);
     while (bodyIss >> word) {
-        output.push_back(PostEntry(offset, wordlocation_t::body));
+        output.push_back(word_t{word, offset, wordlocation_t::body});
         ++offset;
     }
 
     std::getline(document, line);
     if (!checkTagExists(line, "</words>")) {
-        return std::make_pair(documentName, std::vector<PostEntry>{});
+        return std::make_pair(documentName, std::vector<word_t>{});
     }
 
     return std::make_pair(url, output);
@@ -95,4 +95,3 @@ std::pair<std::string, std::vector<PostEntry>> DocStream::nextFile() {
 size_t DocStream::size() {
     return _documents.size();
 }
-

--- a/lib/DocStream/DocStream.hpp
+++ b/lib/DocStream/DocStream.hpp
@@ -2,14 +2,13 @@
 // Parse and batch documents to feed into index
 #pragma once
 
-#include <queue>
-#include <string>
 #include <filesystem>
 #include <fstream>
-#include <sstream>
 #include <iostream>
+#include <queue>
 #include <regex>
-
+#include <sstream>
+#include <string>
 
 using std::cout;
 using std::endl;
@@ -21,9 +20,10 @@ bool checkTagExists(std::string line, std::string tag);
 
 struct BatchNumCompare {
     bool operator()(std::string a, std::string b) {
-        return a[0] > b[0]; // Min-heap (smallest element at top)
+        return a[0] > b[0];  // Min-heap (smallest element at top)
     }
 };
+
 
 class DocStream {
    public:
@@ -32,12 +32,12 @@ class DocStream {
     DocStream(std::string dirPath);
 
     // Parse next file in _documents priority queue
-    std::pair<std::string, std::vector<PostEntry>> nextFile();
+    std::pair<std::string, std::vector<word_t>> nextFile();
 
     size_t size();
 
    private:
-    std::priority_queue<std::string, std::vector<std::string>, BatchNumCompare> _documents;
+    std::priority_queue<std::string, std::vector<std::string>, BatchNumCompare>
+        _documents;
     std::string _dirPath;
 };
-

--- a/lib/IndexElements/IndexChunk.cpp
+++ b/lib/IndexElements/IndexChunk.cpp
@@ -1,21 +1,18 @@
-// #include "IndexChunk.hpp"
+#include "IndexChunk.hpp"
+//
+IndexChunk::IndexChunk() {}
 
-// IndexChunk::IndexChunk() {
+void IndexChunk::addDocument(std::string doc, std::vector<word_t> words) {
+    // Add to set of documents
 
-// }
-
-// void IndexChunk::addDocument(std::string doc, std::vector<postentry_t> words) {
-//     // Add to set of documents
-    
-//     // Iterate over words
-//     for (postentry_t& word : words) {
-//         word.offset = _offset;
-//         cout << word << endl;
-//         if(_postingLists.find(word.word) == _postingLists.end()){
-//             _postingLists.insert(make_pair(word.word, PostingList(word.word)));
-//             _bytesRequired += _postingLists.at(word.word).getOverheadBytes(); 
-//         }
-//         _bytesRequired += _postingLists[word.word].addWord(doc, word);
-//         _offset++;
-//     }
-// }
+    // Iterate over words
+    for (word_t& word : words) {
+        cout << word << endl;
+        if(_postingLists.find(word.word) == _postingLists.end()){
+            _postingLists.insert(make_pair(word.word, PostingList(word.word)));
+            // _bytesRequired += _postingLists.at(word.word).getOverheadBytes();
+        }
+        _postingLists[word.word].addWord(doc, PostEntry(_offset, word.location));
+        _offset++;
+    }
+}

--- a/lib/IndexElements/IndexChunk.hpp
+++ b/lib/IndexElements/IndexChunk.hpp
@@ -2,8 +2,12 @@
 
 #include <unordered_map>
 #include <unordered_set>
+#include <iostream>
+
+using std::cout, std::endl;
 
 #include "PostingList.hpp"
+#include "PostEntry.hpp"
 
 class IndexChunk {
    public:
@@ -16,7 +20,7 @@ class IndexChunk {
     size_t getBytesRequired();
 
     // Iterates through all words in the document and adds document to posting list of the word
-    void addDocument(std::string doc, std::vector<PostEntry> words);
+    void addDocument(std::string doc, std::vector<word_t> words);
 
    private:
     std::unordered_set<std::string> _documents;

--- a/lib/IndexElements/MasterChunk.cpp
+++ b/lib/IndexElements/MasterChunk.cpp
@@ -1,12 +1,10 @@
 #include "MasterChunk.hpp"
 
-MasterChunk::MasterChunk() {
+MasterChunk::MasterChunk() {}
 
-}
-
-void MasterChunk::addDocument(std::string doc, std::vector<PostEntry> words) {
+void MasterChunk::addDocument(std::string doc, std::vector<word_t> words) {
     // Check if index will become too big
     // If too big write to disk and reinitialize _currIndexChunk
-    
+
     _currIndexChunk.addDocument(doc, words);
 }

--- a/lib/IndexElements/MasterChunk.hpp
+++ b/lib/IndexElements/MasterChunk.hpp
@@ -4,20 +4,21 @@
 #include <vector>
 
 #include "IndexChunk.hpp"
+#include "WordLocation.hpp"
 
 class MasterChunk {
-public:
+   public:
     static void Serialize(const char* buf, const MasterChunk& masterChunk);
 
     static MasterChunk Deserailize(const char* buf);
 
     MasterChunk();
 
-    void addDocument(std::string doc, std::vector<PostEntry> words);
+    void addDocument(std::string doc, std::vector<word_t> words);
 
     size_t getBytesRequired();
 
-private:
+   private:
     std::unordered_set<std::string> _indexChunks;
     IndexChunk _currIndexChunk;
     int _numDocuments;

--- a/lib/IndexElements/Post.cpp
+++ b/lib/IndexElements/Post.cpp
@@ -6,49 +6,52 @@ Post::Post() {}
 
 Post::Post(std::string name) : document_name(name), entries() {}
 
-std::string Post::getDocumentName()
-{
+std::string Post::getDocumentName() {
     return document_name;
 }
 
-std::vector<PostEntry> Post::getEntries()
-{
+std::vector<PostEntry> Post::getEntries() {
     return entries;
 }
 
-void Post::addWord(PostEntry word)
-{
+void Post::addWord(PostEntry word) {
     entries.push_back(word);
 }
 
-void Post::Serialize(char* base_region, size_t &offset, const Post& post)
-{
-    spdlog::info("Trying to serialize a Post for the document \"{}\"", post.document_name);
+void Post::Serialize(char* base_region, size_t& offset, const Post& post) {
+    spdlog::info("Trying to serialize a Post for the document \"{}\"",
+                 post.document_name);
     spdlog::info("Offset variable is currently at {}", offset);
 
     // Serialize the document name
-    size_t document_name_size = post.document_name.size() + 1; // account for null terminator
-    std::memcpy(base_region + offset, post.document_name.c_str(), document_name_size);
+    size_t document_name_size =
+        post.document_name.size() + 1;  // account for null terminator
+    std::memcpy(base_region + offset, post.document_name.c_str(),
+                document_name_size);
     offset += document_name_size;
-    spdlog::info("After writing the std::string document_name, offset is now at {}", offset);
+    spdlog::info(
+        "After writing the std::string document_name, offset is now at {}",
+        offset);
 
     // Serialize the vector of word occurrences
     size_t num_words = post.entries.size();
     std::memcpy(base_region + offset, &num_words, sizeof(num_words));
     offset += sizeof(num_words);
-    spdlog::info("After recording the size of the vec<PostEntry>, offset is now at {}", offset);
+    spdlog::info(
+        "After recording the size of the vec<PostEntry>, offset is now at {}",
+        offset);
 
     // Serialize each PostEntry
     for (const auto& word : post.entries) {
         PostEntry::Serialize(base_region, offset, word);
     }
 
-    spdlog::info("Finished serializing Post for the document \"{}\"", post.document_name);
+    spdlog::info("Finished serializing Post for the document \"{}\"",
+                 post.document_name);
     spdlog::info("Offset is now at {}", offset);
 }
 
-Post Post::Deserialize(char* base_region, size_t &offset)
-{
+Post Post::Deserialize(char* base_region, size_t& offset) {
     spdlog::info("Trying to deserialize a Post");
     spdlog::info("Offset variable is currently at {}", offset);
 
@@ -57,14 +60,19 @@ Post Post::Deserialize(char* base_region, size_t &offset)
     // Deserialize the document name
     post.document_name = std::string(base_region + offset);
     offset += post.document_name.size() + 1;
-    spdlog::info("After reading the std::string document_name, offset is now at {}", offset);
+    spdlog::info(
+        "After reading the std::string document_name, offset is now at {}",
+        offset);
 
     // Deserialize the number of words in the vector
     size_t num_of_words;
     std::memcpy(&num_of_words, base_region + offset, sizeof(num_of_words));
     offset += sizeof(num_of_words);
     post.entries.resize(num_of_words);
-    spdlog::info("After reading the size of the vector and resizing, offset is now at {}", offset);
+    spdlog::info(
+        "After reading the size of the vector and resizing, offset is now at "
+        "{}",
+        offset);
 
     // Deserialize each PostEntry
     for (size_t i = 0; i < num_of_words; ++i) {

--- a/lib/IndexElements/Post.hpp
+++ b/lib/IndexElements/Post.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "PostEntry.hpp"
 
 /**
@@ -10,43 +12,42 @@
  * name and a collection of word occurrences (PostEntry objects). It provides functionality for adding words,
  * getting word entries, and serializing or deserializing the post's data.
  */
-class Post
-{
-    public:
-        /**
+class Post {
+   public:
+    /**
          * @brief Default constructor for a Post.
          */
-        Post();
+    Post();
 
-        /**
+    /**
          * @brief Constructs a Post with a specified name.
          * 
          * @param name The name of the document.
          */
-        Post(std::string name);
+    Post(std::string name);
 
-        /**
+    /**
          * @brief Returns the name of this document that this Post represents.
          * 
          * @return A std::string of the document's name.
          */
-        std::string getDocumentName();
+    std::string getDocumentName();
 
-        /**
+    /**
          * @brief Returns a vector containing all word occurrences (PostEntry objects) in the post.
          * 
          * @return A vector of PostEntry objects.
          */
-        std::vector<PostEntry> getEntries();
+    std::vector<PostEntry> getEntries();
 
-        /**
+    /**
          * @brief Adds a word occurrence (PostEntry) to the post.
          * 
          * @param word The word occurrence (PostEntry) to add.
          */
-        void addWord(PostEntry word);
+    void addWord(PostEntry word);
 
-        /**
+    /**
          * @brief Serializes a given Post object into a specific region of memory.
          * 
          * This function writes the Post object's data into the memory region starting at the given
@@ -67,9 +68,9 @@ class Post
          * @post Writes the bytes of the Post object into memory at the calculated region.
          * @post Updates `offset` to the next available memory location.
          */
-        static void Serialize(char* base_region, size_t &offset, const Post& post);
+    static void Serialize(char* base_region, size_t& offset, const Post& post);
 
-        /**
+    /**
          * @brief Deserializes a Post object from a specific region of memory.
          * 
          * This function reconstructs a Post object from the bytes in the specified memory region, 
@@ -84,12 +85,12 @@ class Post
          * @pre `base_region + offset` must point to a valid serialized Post object.
          * @post A Post object is created and the offset is updated.
          */
-        static Post Deserialize(char* base_region, size_t &offset);
+    static Post Deserialize(char* base_region, size_t& offset);
 
-    private:
-        /// The name of the document.
-        std::string document_name;
+   private:
+    /// The name of the document.
+    std::string document_name;
 
-        /// A vector containing the word occurrences (PostEntry objects) in the document.
-        std::vector<PostEntry> entries;
+    /// A vector containing the word occurrences (PostEntry objects) in the document.
+    std::vector<PostEntry> entries;
 };

--- a/lib/IndexElements/PostEntry.cpp
+++ b/lib/IndexElements/PostEntry.cpp
@@ -4,10 +4,10 @@
 
 PostEntry::PostEntry() {}
 
-PostEntry::PostEntry(uint32_t delta, wordlocation_t location_found) : delta(delta), location_found(location_found) {}
+PostEntry::PostEntry(uint32_t delta, wordlocation_t location_found)
+    : delta(delta), location_found(location_found) {}
 
-std::ostream& operator<<(std::ostream& os, const PostEntry& obj)
-{
+std::ostream& operator<<(std::ostream& os, const PostEntry& obj) {
     os << "PostEntry{ delta=" << obj.delta << " location_found=";
     switch (obj.location_found) {
         case (wordlocation_t::title):
@@ -26,47 +26,54 @@ std::ostream& operator<<(std::ostream& os, const PostEntry& obj)
     return os;
 }
 
-uint32_t PostEntry::getDelta()
-{
+uint32_t PostEntry::getDelta() {
     return delta;
 }
 
-wordlocation_t PostEntry::getLocationFound()
-{
+wordlocation_t PostEntry::getLocationFound() {
     return location_found;
 }
 
-void PostEntry::Serialize(char* base_region, size_t &offset, const PostEntry &word_occurrence)
-{
+void PostEntry::Serialize(char* base_region, size_t& offset,
+                          const PostEntry& word_occurrence) {
     spdlog::info("Trying to serialize a PostEntry");
     spdlog::info("Offset variable is currently at {}", offset);
 
-    std::memcpy(base_region + offset, &word_occurrence.delta, sizeof(word_occurrence.delta));
+    std::memcpy(base_region + offset, &word_occurrence.delta,
+                sizeof(word_occurrence.delta));
     offset += sizeof(word_occurrence.delta);
-    spdlog::info("After writing the uint32_t delta, offset is now at {}", offset);
+    spdlog::info("After writing the uint32_t delta, offset is now at {}",
+                 offset);
 
-    std::memcpy(base_region + offset, &word_occurrence.location_found, sizeof(word_occurrence.location_found));
+    std::memcpy(base_region + offset, &word_occurrence.location_found,
+                sizeof(word_occurrence.location_found));
     offset += sizeof(word_occurrence.location_found);
-    spdlog::info("After writing the enum int location_found, offset is now at {}", offset);
+    spdlog::info(
+        "After writing the enum int location_found, offset is now at {}",
+        offset);
 
     spdlog::info("Serializing this PostEntry complete");
     spdlog::info("Offset variable is now at {}", offset);
 }
 
-PostEntry PostEntry::Deserialize(char* base_region, size_t &offset)
-{
+PostEntry PostEntry::Deserialize(char* base_region, size_t& offset) {
     spdlog::info("Trying to deserialize a PostEntry");
     spdlog::info("Offset variable is currently at {}", offset);
 
     PostEntry word_occurrence;
 
-    std::memcpy(&word_occurrence.delta, base_region + offset, sizeof(word_occurrence.delta));
+    std::memcpy(&word_occurrence.delta, base_region + offset,
+                sizeof(word_occurrence.delta));
     offset += sizeof(word_occurrence.delta);
-    spdlog::info("After reading the uint32_t delta, offset is now at {}", offset);
+    spdlog::info("After reading the uint32_t delta, offset is now at {}",
+                 offset);
 
-    std::memcpy(&word_occurrence.location_found, base_region + offset, sizeof(word_occurrence.location_found));
+    std::memcpy(&word_occurrence.location_found, base_region + offset,
+                sizeof(word_occurrence.location_found));
     offset += sizeof(word_occurrence.location_found);
-    spdlog::info("After reading the enum int location_found, offset is now at {}", offset);
+    spdlog::info(
+        "After reading the enum int location_found, offset is now at {}",
+        offset);
 
     spdlog::info("Deserializing a PostEntry complete");
     spdlog::info("Offset is now at {}", offset);

--- a/lib/IndexElements/PostEntry.hpp
+++ b/lib/IndexElements/PostEntry.hpp
@@ -12,42 +12,41 @@
  * This class is the most basic, atomic part of the inverted word index.
  * It provides capabilities to serialize and deserialize to/from storage.
  */
-class PostEntry
-{
-    public:
-        /** 
+class PostEntry {
+   public:
+    /** 
          * @brief Default constructor for a PostEntry.
          */
-        PostEntry();
+    PostEntry();
 
-        /** 
+    /** 
          * @brief Constructs a PostEntry object.
          * @param delta The relative position of this word in the index chunk.
          * @param location_found The section of the page where the word was found.
          */
-        PostEntry(uint32_t delta, wordlocation_t location_found);
+    PostEntry(uint32_t delta, wordlocation_t location_found);
 
-        // Friend function to overload the == operator for PostEntry comparison
-        // friend bool operator==(const PostEntry& lhs, const PostEntry& rhs);
+    // Friend function to overload the == operator for PostEntry comparison
+    // friend bool operator==(const PostEntry& lhs, const PostEntry& rhs);
 
-        // Friend function to overload the << operator for PostEntry printing
-        friend std::ostream& operator<<(std::ostream& os, const PostEntry& obj);
+    // Friend function to overload the << operator for PostEntry printing
+    friend std::ostream& operator<<(std::ostream& os, const PostEntry& obj);
 
-        /**
+    /**
          * @brief Returns the delta of this PostEntry.
          * 
          * @return A uint32_t of this PostEntry's delta.
          */
-        uint32_t getDelta();
+    uint32_t getDelta();
 
-        /**
+    /**
          * @brief Returns the location of where this word occurred.
          * 
          * @return A wordlocation_t of where this word occurred.
          */
-        wordlocation_t getLocationFound();
+    wordlocation_t getLocationFound();
 
-        /**
+    /**
          * @brief Serializes a given PostEntry object into a specific region of memory.
          *
          * @param base_region A pointer to the beginning of the contiguous memory region 
@@ -65,9 +64,10 @@ class PostEntry
          * @post Writes the bytes of the PostEntry object into memory at the calculated region.
          * @post Updates `offset` to the next available memory location.
          */
-        static void Serialize(char* base_region, size_t &offset, const PostEntry &word_occurrence);
+    static void Serialize(char* base_region, size_t& offset,
+                          const PostEntry& word_occurrence);
 
-        /**
+    /**
          * @brief Deserializes a PostEntry object from a specific region of memory.
          *
          * @param base_region A pointer to the beginning of the memory region containing the object.
@@ -79,13 +79,13 @@ class PostEntry
          * @pre `base_region + offset` must point to a valid serialized PostEntry object.
          * @post A PostEntry object is created and the offset is updated.
          */
-        static PostEntry Deserialize(char* base_region, size_t &offset);
+    static PostEntry Deserialize(char* base_region, size_t& offset);
 
-    private:
-        /// The relative position of this word in the index chunk.
-        /// @todo Convert this to use relative deltas.
-        uint32_t delta;
-        
-        /// The section of the page where the word was found.
-        wordlocation_t location_found;
+    /// The relative position of this word in the index chunk.
+    /// @todo Convert this to use relative deltas.
+    uint32_t delta;
+   private:
+
+    /// The section of the page where the word was found.
+    wordlocation_t location_found;
 };

--- a/lib/IndexElements/PostingList.cpp
+++ b/lib/IndexElements/PostingList.cpp
@@ -6,13 +6,11 @@ PostingList::PostingList() {}
 
 PostingList::PostingList(const std::string& word) : word(word) {}
 
-std::string PostingList::getWord()
-{
+std::string PostingList::getWord() {
     return word;
 }
 
-void PostingList::addWord(std::string doc, PostEntry word)
-{
+void PostingList::addWord(std::string doc, PostEntry word) {
     if (posts.empty()) {
         posts.emplace_back(doc);
     }
@@ -24,38 +22,43 @@ void PostingList::addWord(std::string doc, PostEntry word)
     posts.back().addWord(word);
 }
 
-std::vector<Post> PostingList::getPosts()
-{
+std::vector<Post> PostingList::getPosts() {
     return posts;
 }
 
-void PostingList::Serialize(char* base_region, size_t &offset, const PostingList& postingList)
-{
-    spdlog::info("Trying to serialize a PostingList for the word {}", postingList.word);
+void PostingList::Serialize(char* base_region, size_t& offset,
+                            const PostingList& postingList) {
+    spdlog::info("Trying to serialize a PostingList for the word {}",
+                 postingList.word);
     spdlog::info("Offset variable is currently at {}", offset);
 
     // Serialize the word representing the PostingList
     size_t postingList_word_size = postingList.word.size() + 1;
-    std::memcpy(base_region + offset, postingList.word.c_str(), postingList_word_size);
+    std::memcpy(base_region + offset, postingList.word.c_str(),
+                postingList_word_size);
     offset += postingList_word_size;
-    spdlog::info("After writing the word this PostingList represents, offset is now at {}", offset);
+    spdlog::info(
+        "After writing the word this PostingList represents, offset is now at "
+        "{}",
+        offset);
 
     // Serialize the vector of posts
     size_t num_posts = postingList.posts.size();
     std::memcpy(base_region + offset, &num_posts, sizeof(num_posts));
     offset += sizeof(num_posts);
-    spdlog::info("After writing the size of the vec<Post>, offset is now at {}", offset);
+    spdlog::info("After writing the size of the vec<Post>, offset is now at {}",
+                 offset);
 
     for (const auto& post : postingList.posts) {
         Post::Serialize(base_region, offset, post);
     }
 
-    spdlog::info("Finished serializing PostingList for the word {}", postingList.word);
+    spdlog::info("Finished serializing PostingList for the word {}",
+                 postingList.word);
     spdlog::info("Offset is now at {}", offset);
 }
 
-PostingList PostingList::Deserialize(char* base_region, size_t &offset)
-{
+PostingList PostingList::Deserialize(char* base_region, size_t& offset) {
     spdlog::info("Trying to deserialize a PostingList");
     spdlog::info("Offset variable is currently at {}", offset);
 
@@ -64,14 +67,20 @@ PostingList PostingList::Deserialize(char* base_region, size_t &offset)
     // Deserialize the word associated with the PostingList
     postingList.word = std::string(base_region + offset);
     offset += postingList.word.size() + 1;
-    spdlog::info("After reading the word that this PostingList represents, offset is now at {}", offset);
+    spdlog::info(
+        "After reading the word that this PostingList represents, offset is "
+        "now at {}",
+        offset);
 
     // Deserialize the number of posts
     size_t num_of_posts;
     std::memcpy(&num_of_posts, base_region + offset, sizeof(num_of_posts));
     offset += sizeof(num_of_posts);
     postingList.posts.resize(num_of_posts);
-    spdlog::info("After reading the size of the vector and resizing, offset is now at {}", offset);
+    spdlog::info(
+        "After reading the size of the vector and resizing, offset is now at "
+        "{}",
+        offset);
 
     // Deserialize each post in the vector
     for (size_t i = 0; i < num_of_posts; ++i) {

--- a/lib/IndexElements/PostingList.hpp
+++ b/lib/IndexElements/PostingList.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <vector>
 
 #include "Post.hpp"
 
@@ -11,45 +12,44 @@
  * This class is used to store a collection of posts that relate to a specific word. Each post contains information about 
  * a document and its associated word occurrences. It supports serialization and deserialization to/from memory.
  */
-class PostingList
-{
-    public:
-        /**
+class PostingList {
+   public:
+    /**
          * @brief Default constructor for a PostingList.
          *
          */
-        PostingList();
+    PostingList();
 
-        /**
+    /**
          * @brief Constructs a PostingList object for a specific word.
          *
          * @param word The word that this PostingList represents.
          */
-        PostingList(const std::string& word);
+    PostingList(const std::string& word);
 
-        /**
+    /**
          * @brief Gets the word associated with this PostingList.
          *
          * @return The word associated with this PostingList.
          */
-        std::string getWord();
+    std::string getWord();
 
-        /**
+    /**
          * @brief Adds a new word (PostEntry) to the list of posts in this PostingList.
          *
          * @param doc The document name where the word is found.
          * @param word The PostEntry object that contains the word occurrence information.
          */
-        void addWord(std::string doc, PostEntry word);
+    void addWord(std::string doc, PostEntry word);
 
-        /**
+    /**
          * @brief Retrieves the list of posts associated with this PostingList.
          *
          * @return A vector of Post objects associated with this PostingList.
          */
-        std::vector<Post> getPosts();
+    std::vector<Post> getPosts();
 
-        /**
+    /**
          * @brief Serializes a given PostingList object into a specific region of memory.
          *
          * @param base_region A pointer to the beginning of the contiguous memory region 
@@ -67,9 +67,10 @@ class PostingList
          * @post Writes the bytes of the PostingList object into memory at the calculated region.
          * @post Updates `offset` to the next available memory location.
          */
-        static void Serialize(char* base_region, size_t &offset, const PostingList& postingList);
+    static void Serialize(char* base_region, size_t& offset,
+                          const PostingList& postingList);
 
-        /**
+    /**
          * @brief Deserializes a PostingList object from a specific region of memory.
          *
          * @param base_region A pointer to the beginning of the memory region containing the object.
@@ -81,15 +82,15 @@ class PostingList
          * @pre `base_region + offset` must point to a valid serialized PostingList object.
          * @post A PostingList object is created and the offset is updated.
          */
-        static PostingList Deserialize(char* base_region, size_t &offset);
+    static PostingList Deserialize(char* base_region, size_t& offset);
 
-    private:
-        /// The word associated with this PostingList
-        std::string word;
+   private:
+    /// The word associated with this PostingList
+    std::string word;
 
-        /// A vector of Post objects associated with the word
-        std::vector<Post> posts;
+    /// A vector of Post objects associated with the word
+    std::vector<Post> posts;
 
-        /// A synchronization table for efficient access
-        std::unordered_map<uint32_t, std::tuple<size_t>> sync_table;
+    /// A synchronization table for efficient access
+    std::unordered_map<uint32_t, std::tuple<size_t>> sync_table;
 };

--- a/lib/IndexElements/WordLocation.hpp
+++ b/lib/IndexElements/WordLocation.hpp
@@ -1,7 +1,35 @@
 #pragma once
 
+#include <string>
+#include <iostream>
+
 enum class wordlocation_t {
     title = 0,
     bold = 1,
     body = 2,
+};
+
+struct word_t {
+    std::string word;
+    uint32_t offset;
+    wordlocation_t location;
+
+    friend std::ostream& operator<<(std::ostream& os, const word_t& w) {
+        os << "word_t{ word=" << w.word << " offset=" << w.offset << " location=";
+        switch (w.location) {
+            case (wordlocation_t::title):
+                os << "title";
+                break;
+            case (wordlocation_t::bold):
+                os << "bold";
+                break;
+            case (wordlocation_t::body):
+                os << "body";
+                break;
+            default:
+                os << "unknown";
+        }
+        os << " }";
+        return os;
+    }
 };

--- a/src/reindex.cpp
+++ b/src/reindex.cpp
@@ -3,20 +3,19 @@
 #include <spdlog/spdlog.h>
 #include <argparse/argparse.hpp>
 
-
-#include <sys/mman.h>    // For shm_open, mmap, PROT_READ, PROT_WRITE, MAP_SHARED, munmap
-#include <sys/stat.h>    // For mode constants
-#include <fcntl.h>       // For O_CREAT, O_RDWR
-#include <unistd.h>      // For ftruncate, close
+#include <fcntl.h>  // For O_CREAT, O_RDWR
+#include <sys/mman.h>  // For shm_open, mmap, PROT_READ, PROT_WRITE, MAP_SHARED, munmap
+#include <sys/stat.h>  // For mode constants
+#include <unistd.h>    // For ftruncate, close
 
 #include "DocStream.hpp"
 #include "MasterChunk.hpp"
-#include "PostingList.hpp"
 #include "Post.hpp"
+#include "PostingList.hpp"
 #include "WordLocation.hpp"
 
 void* create_mmap_region(int& fd, size_t size) {
-    fd = open("test_posting_list", O_CREAT | O_RDWR, 0666); // 0666 = rw
+    fd = open("test_posting_list", O_CREAT | O_RDWR, 0666);  // 0666 = rw
     ftruncate(fd, size);
     return mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 }
@@ -31,7 +30,8 @@ void* read_mmap_region(int& fd, size_t size) {
     size_t fileSize;
     if (fstat(fd, &fileStat) == -1) {
         close(fd);
-        throw std::runtime_error("Error: Failed to get file size for test_posting_list");
+        throw std::runtime_error(
+            "Error: Failed to get file size for test_posting_list");
     }
     fileSize = fileStat.st_size;
 
@@ -44,164 +44,11 @@ void* read_mmap_region(int& fd, size_t size) {
     return mappedRegion;
 }
 
-void test_serializiation() {
-    int fd;
-    const size_t REGION_SIZE = 4096;
-    void* base_region = create_mmap_region(fd, REGION_SIZE);
-
-    PostingList* postingList = new PostingList("cat");
-
-    // let's say there is a document named cnn/index.html
-    std::string cnn_doc = "cnn/index.html";
-    // and on this document, there are a couple occurrences of the word "cat" in the body
-    PostEntry word_occurrence_1 = {5, wordlocation_t::body};
-    PostEntry word_occurrence_2 = {10, wordlocation_t::title};
-    PostEntry word_occurrence_3 = {17, wordlocation_t::body};
-
-    // and let's say there is another document called fox/index.html
-    std::string fox_doc = "fox/index.html";
-    PostEntry word_occurrence_4 = {20, wordlocation_t::body};
-    PostEntry word_occurrence_5 = {25, wordlocation_t::title};
-    PostEntry word_occurrence_6 = {29, wordlocation_t::title};
-    PostEntry word_occurrence_7 = {40, wordlocation_t::body};
-
-    postingList->addWord(cnn_doc, word_occurrence_1);
-    postingList->addWord(cnn_doc, word_occurrence_2);
-    postingList->addWord(cnn_doc, word_occurrence_3);
-
-    postingList->addWord(fox_doc, word_occurrence_4);
-    postingList->addWord(fox_doc, word_occurrence_5);
-    postingList->addWord(fox_doc, word_occurrence_6);
-    postingList->addWord(fox_doc, word_occurrence_7);
-
-    size_t offset = 0;
-    PostingList::Serialize(static_cast<char*>(base_region), offset, *postingList);
-
-    std::cout << "PostingList serialized to mmap.\n";
-
-    munmap(base_region, REGION_SIZE);
-    close(fd);
-    delete postingList;
-}
-
-void test_deserialization() {
-    int fd;
-    const size_t REGION_SIZE = 4096;
-    void* base_region = read_mmap_region(fd, REGION_SIZE);
-    size_t offset = 0;
-
-    PostingList postingList = PostingList::Deserialize(static_cast<char*>(base_region), offset);
-
-    if (postingList.getWord() == "cat") {
-        std::cout << "Passed!" << std::endl;
-    }
-    else {
-        std::cout << "Failed!" << std::endl;
-        exit(1);
-    }
-
-    if (postingList.getPosts().size() == 2) { // one for cnn and one for fox
-        std::cout << "Passed!" << std::endl;
-    }
-    else {
-        std::cout << "Failed!" << std::endl;
-        exit(1);
-    }
-
-    std::vector<Post> catPostingList = postingList.getPosts();
-    Post cnnPost = catPostingList[0];
-    if (cnnPost.getDocumentName() == "cnn/index.html") {
-        std::cout << "Passed!" << std::endl;
-    }
-    else {
-        std::cout << "Failed!" << std::endl;
-        exit(1);
-    }
-
-    auto entries = cnnPost.getEntries();
-
-    PostEntry cnn_word_occurrence_1 = entries[0];
-    if (cnn_word_occurrence_1.getDelta() == 5 && cnn_word_occurrence_1.getLocationFound() == wordlocation_t::body) {
-        std::cout << "Passed!" << std::endl;
-    }
-    else {
-        std::cout << "Failed!" << std::endl;
-        exit(1);
-    }
-
-    PostEntry cnn_word_occurrence_2 = entries[1];
-    if (cnn_word_occurrence_2.getDelta() == 10 && cnn_word_occurrence_2.getLocationFound() == wordlocation_t::title) {
-        std::cout << "Passed!" << std::endl;
-    }
-    else {
-        std::cout << "Failed!" << std::endl;
-        exit(1);
-    }
-
-    PostEntry cnn_word_occurrence_3 = entries[2];
-    if (cnn_word_occurrence_3.getDelta() == 17 && cnn_word_occurrence_3.getLocationFound() == wordlocation_t::body) {
-        std::cout << "Passed!" << std::endl;
-    }
-    else {
-        std::cout << "Failed!" << std::endl;
-        exit(1);
-    }
-
-    Post foxPost = catPostingList[1];
-    if (foxPost.getDocumentName() == "fox/index.html") {
-        std::cout << "Passed!" << std::endl;
-    }
-    else {
-        std::cout << "Failed!" << std::endl;
-        exit(1);
-    }
-
-    entries = foxPost.getEntries();
-
-    PostEntry fox_word_occurrence_1 = entries[0];
-    if (fox_word_occurrence_1.getDelta() == 20 && fox_word_occurrence_1.getLocationFound() == wordlocation_t::body) {
-        std::cout << "Passed!" << std::endl;
-    }
-    else {
-        std::cout << "Failed!" << std::endl;
-        exit(1);
-    }
-
-    PostEntry fox_word_occurrence_2 = entries[1];
-    if (fox_word_occurrence_2.getDelta() == 25 && fox_word_occurrence_2.getLocationFound() == wordlocation_t::title) {
-        std::cout << "Passed!" << std::endl;
-    }
-    else {
-        std::cout << "Failed!" << std::endl;
-        exit(1);
-    }
-
-    PostEntry fox_word_occurrence_3 = entries[2];
-    if (fox_word_occurrence_3.getDelta() == 29 && fox_word_occurrence_3.getLocationFound() == wordlocation_t::title) {
-        std::cout << "Passed!" << std::endl;
-    }
-    else {
-        std::cout << "Failed!" << std::endl;
-        exit(1);
-    }
-
-    PostEntry fox_word_occurrence_4 = entries[3];
-    if (fox_word_occurrence_4.getDelta() == 40 && fox_word_occurrence_4.getLocationFound() == wordlocation_t::body) {
-        std::cout << "Passed!" << std::endl;
-    }
-    else {
-        std::cout << "Failed!" << std::endl;
-        exit(1);
-    }
-
-    std::cout << "All tests passed!" << std::endl;
-}
-
 int main(int argc, char** argv) {
     argparse::ArgumentParser program("reindex");
     program.add_argument("-i", "--input")
-      .required()
-      .help("Specify the input file.");
+        .required()
+        .help("Specify the input file.");
 
     try {
         program.parse_args(argc, argv);
@@ -212,26 +59,23 @@ int main(int argc, char** argv) {
     }
 
     std::string inputDir = program.get<std::string>("-i");
+    spdlog::info("Input directory: {}", inputDir);
     spdlog::info("======= Reindex Started =======");
+    // Initialize DocStream object
+    DocStream docStream(inputDir);
+    MasterChunk master;
 
-    test_serializiation();
-    test_deserialization();
+    while (docStream.size() > 0) {
+        std::pair<std::string, std::vector<word_t>> nextDoc = docStream.nextFile();
+        auto [document, words] = nextDoc;
+        if (words.empty()) {
+            spdlog::error("Error parsing {}", document);
+            continue;
+        }
+        master.addDocument(document, words);
+    }
 
     return 0;
 }
 
-// spdlog::info("Input directory: {}", inputDir);
 
-// Initialize DocStream object
-// DocStream docStream(inputDir);
-// MasterChunk master;
-
-// while (docStream.size() > 0) {
-//     std::pair<docname, words> nextDoc = docStream.nextFile();
-//     auto [document, words] = nextDoc;
-//     if (words.empty()) {
-//         spdlog::error("Error parsing {}", document);
-//         continue;
-//     }
-//     master.addDocument(document, words);
-// }

--- a/tests/TestPostingList.cpp
+++ b/tests/TestPostingList.cpp
@@ -1,7 +1,42 @@
 #include <gtest/gtest.h>
 
+#include <fcntl.h>  // For O_CREAT, O_RDWR
+#include <sys/mman.h>  // For shm_open, mmap, PROT_READ, PROT_WRITE, MAP_SHARED, munmap
+#include <sys/stat.h>  // For mode constants
+#include <unistd.h>    // For ftruncate, close
+
 #include "PostingList.hpp"
 #include "WordLocation.hpp"
+
+void* create_mmap_region(int& fd, size_t size) {
+    fd = open("test_posting_list", O_CREAT | O_RDWR, 0666);  // 0666 = rw
+    ftruncate(fd, size);
+    return mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+}
+
+void* read_mmap_region(int& fd, size_t size) {
+    fd = open("test_posting_list", O_RDONLY);
+    if (fd == -1) {
+        throw std::runtime_error("Failed to open file");
+    }
+
+    struct stat fileStat;
+    size_t fileSize;
+    if (fstat(fd, &fileStat) == -1) {
+        close(fd);
+        throw std::runtime_error(
+            "Error: Failed to get file size for test_posting_list");
+    }
+    fileSize = fileStat.st_size;
+
+    void* mappedRegion = mmap(nullptr, fileSize, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (mappedRegion == MAP_FAILED) {
+        close(fd);
+        throw std::runtime_error("Error: Failed to memory-map file");
+    }
+
+    return mappedRegion;
+}
 
 TEST(BasicPostingList, TestConstructor) {
     PostingList pl("hello");
@@ -19,10 +54,11 @@ TEST(BasicPostingList, TestAddWord) {
 
     // Access posts using getPosts()
     auto posts = pl.getPosts();
-    
+
     // First post
     EXPECT_EQ(posts[0].getDocumentName(), "doc1");
-    auto wordEntries1 = posts[0].getEntries(); // Get entries for the first post
+    auto wordEntries1 =
+        posts[0].getEntries();  // Get entries for the first post
     EXPECT_EQ(wordEntries1[0].getDelta(), w1.getDelta());
     EXPECT_EQ(wordEntries1[0].getLocationFound(), w1.getLocationFound());
     EXPECT_EQ(wordEntries1[1].getDelta(), w2.getDelta());
@@ -30,7 +66,164 @@ TEST(BasicPostingList, TestAddWord) {
 
     // Second post
     EXPECT_EQ(posts[1].getDocumentName(), "doc2");
-    auto wordEntries2 = posts[1].getEntries(); // Get entries for the second post
+    auto wordEntries2 =
+        posts[1].getEntries();  // Get entries for the second post
     EXPECT_EQ(wordEntries2[0].getDelta(), w3.getDelta());
     EXPECT_EQ(wordEntries2[0].getLocationFound(), w3.getLocationFound());
+}
+
+void test_serializiation() {
+    int fd;
+    const size_t REGION_SIZE = 4096;
+    void* base_region = create_mmap_region(fd, REGION_SIZE);
+
+    PostingList* postingList = new PostingList("cat");
+
+    // let's say there is a document named cnn/index.html
+    std::string cnn_doc = "cnn/index.html";
+    // and on this document, there are a couple occurrences of the word "cat" in the body
+    PostEntry word_occurrence_1 = {5, wordlocation_t::body};
+    PostEntry word_occurrence_2 = {10, wordlocation_t::title};
+    PostEntry word_occurrence_3 = {17, wordlocation_t::body};
+
+    // and let's say there is another document called fox/index.html
+    std::string fox_doc = "fox/index.html";
+    PostEntry word_occurrence_4 = {20, wordlocation_t::body};
+    PostEntry word_occurrence_5 = {25, wordlocation_t::title};
+    PostEntry word_occurrence_6 = {29, wordlocation_t::title};
+    PostEntry word_occurrence_7 = {40, wordlocation_t::body};
+
+    postingList->addWord(cnn_doc, word_occurrence_1);
+    postingList->addWord(cnn_doc, word_occurrence_2);
+    postingList->addWord(cnn_doc, word_occurrence_3);
+
+    postingList->addWord(fox_doc, word_occurrence_4);
+    postingList->addWord(fox_doc, word_occurrence_5);
+    postingList->addWord(fox_doc, word_occurrence_6);
+    postingList->addWord(fox_doc, word_occurrence_7);
+
+    size_t offset = 0;
+    PostingList::Serialize(static_cast<char*>(base_region), offset,
+                           *postingList);
+
+    std::cout << "PostingList serialized to mmap.\n";
+
+    munmap(base_region, REGION_SIZE);
+    close(fd);
+    delete postingList;
+}
+
+void test_deserialization() {
+    int fd;
+    const size_t REGION_SIZE = 4096;
+    void* base_region = read_mmap_region(fd, REGION_SIZE);
+    size_t offset = 0;
+
+    PostingList postingList =
+        PostingList::Deserialize(static_cast<char*>(base_region), offset);
+
+    if (postingList.getWord() == "cat") {
+        std::cout << "Passed!" << std::endl;
+    } else {
+        std::cout << "Failed!" << std::endl;
+        exit(1);
+    }
+
+    if (postingList.getPosts().size() == 2) {  // one for cnn and one for fox
+        std::cout << "Passed!" << std::endl;
+    } else {
+        std::cout << "Failed!" << std::endl;
+        exit(1);
+    }
+
+    std::vector<Post> catPostingList = postingList.getPosts();
+    Post cnnPost = catPostingList[0];
+    if (cnnPost.getDocumentName() == "cnn/index.html") {
+        std::cout << "Passed!" << std::endl;
+    } else {
+        std::cout << "Failed!" << std::endl;
+        exit(1);
+    }
+
+    auto entries = cnnPost.getEntries();
+
+    PostEntry cnn_word_occurrence_1 = entries[0];
+    if (cnn_word_occurrence_1.getDelta() == 5 &&
+        cnn_word_occurrence_1.getLocationFound() == wordlocation_t::body) {
+        std::cout << "Passed!" << std::endl;
+    } else {
+        std::cout << "Failed!" << std::endl;
+        exit(1);
+    }
+
+    PostEntry cnn_word_occurrence_2 = entries[1];
+    if (cnn_word_occurrence_2.getDelta() == 10 &&
+        cnn_word_occurrence_2.getLocationFound() == wordlocation_t::title) {
+        std::cout << "Passed!" << std::endl;
+    } else {
+        std::cout << "Failed!" << std::endl;
+        exit(1);
+    }
+
+    PostEntry cnn_word_occurrence_3 = entries[2];
+    if (cnn_word_occurrence_3.getDelta() == 17 &&
+        cnn_word_occurrence_3.getLocationFound() == wordlocation_t::body) {
+        std::cout << "Passed!" << std::endl;
+    } else {
+        std::cout << "Failed!" << std::endl;
+        exit(1);
+    }
+
+    Post foxPost = catPostingList[1];
+    if (foxPost.getDocumentName() == "fox/index.html") {
+        std::cout << "Passed!" << std::endl;
+    } else {
+        std::cout << "Failed!" << std::endl;
+        exit(1);
+    }
+
+    entries = foxPost.getEntries();
+
+    PostEntry fox_word_occurrence_1 = entries[0];
+    if (fox_word_occurrence_1.getDelta() == 20 &&
+        fox_word_occurrence_1.getLocationFound() == wordlocation_t::body) {
+        std::cout << "Passed!" << std::endl;
+    } else {
+        std::cout << "Failed!" << std::endl;
+        exit(1);
+    }
+
+    PostEntry fox_word_occurrence_2 = entries[1];
+    if (fox_word_occurrence_2.getDelta() == 25 &&
+        fox_word_occurrence_2.getLocationFound() == wordlocation_t::title) {
+        std::cout << "Passed!" << std::endl;
+    } else {
+        std::cout << "Failed!" << std::endl;
+        exit(1);
+    }
+
+    PostEntry fox_word_occurrence_3 = entries[2];
+    if (fox_word_occurrence_3.getDelta() == 29 &&
+        fox_word_occurrence_3.getLocationFound() == wordlocation_t::title) {
+        std::cout << "Passed!" << std::endl;
+    } else {
+        std::cout << "Failed!" << std::endl;
+        exit(1);
+    }
+
+    PostEntry fox_word_occurrence_4 = entries[3];
+    if (fox_word_occurrence_4.getDelta() == 40 &&
+        fox_word_occurrence_4.getLocationFound() == wordlocation_t::body) {
+        std::cout << "Passed!" << std::endl;
+    } else {
+        std::cout << "Failed!" << std::endl;
+        exit(1);
+    }
+
+    std::cout << "All tests passed!" << std::endl;
+}
+
+TEST(BasicPostingList, SerializeDeserialize) {
+    test_serializiation();
+    test_deserialization();
 }


### PR DESCRIPTION
I moved the tests in `reindex.cpp` to `tests/TestPostingList.cpp`

I also put `word_t` back into `lib/IndexElements/WordLocation.hpp`. `word_t` is what is outputted from `DocStream` and then the `PostEntry` for that word is created in `IndexChunk::addDocument`. I needed to do this because we need to know the actual word when adding it to the PostingList.